### PR TITLE
fix: 修复 解决一键部署报错 (closes #10)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,12 @@
+name = "cf-r2-webdav"
+main = "src/index.ts"
+compatibility_date = "2023-01-01"
+
+[vars]
+USERNAME = "$USERNAME"
+PASSWORD = "$PASSWORD"
+BUCKET_NAME = "$BUCKET_NAME"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "$BUCKET_NAME"


### PR DESCRIPTION
fix: 修复 在提供的目录中找不到 wrangler.json、wrangler.jsnc 或 wrangler.toml 文件,解决一键部署报错 (closes #10)